### PR TITLE
Add error reporting and rate limiter

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,13 +5,26 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+	"sync"
+	"time"
 )
 
 const baseURL string = "https://api.themoviedb.org/3"
 
+var (
+	requestMutex   = &sync.Mutex{}
+	rateLimitReset time.Time
+)
+
 // TMDb container struct for global properties
 type TMDb struct {
 	apiKey string
+}
+
+type apiStatus struct {
+	Code    int    `json:"status_code"`
+	Message string `json:"status_message"`
 }
 
 // Init setup the apiKey
@@ -27,14 +40,47 @@ func ToJSON(payload interface{}) (string, error) {
 }
 
 func getTmdb(url string, payload interface{}) (interface{}, error) {
+	// Go single-threaded so we can deal with the rate limit
+	requestMutex.Lock()
+	defer requestMutex.Unlock()
+
+	now := time.Now()
+	if rateLimitReset.After(now) { // We have a reset time in the future, so we're out of requests
+		// Wait for rate limiter to be reset
+		<-time.After(now.Sub(rateLimitReset))
+	}
+
 	res, err := http.Get(url)
-	if err == nil {
-		body, err := ioutil.ReadAll(res.Body)
+	if res.Header.Get(`x-ratelimit-remaining`) == `0` { // Out of requests for this period
+		reset := res.Header.Get(`x-ratelimit-reset`)
+		iReset, err := strconv.ParseInt(reset, 10, 64)
 		if err == nil {
-			json.Unmarshal(body, &payload)
+			// Set the reset time here, the next request will trip it
+			rateLimitReset = time.Unix(iReset, 0)
 		}
 	}
-	return payload, err
+
+	if err != nil { // HTTP connection error
+		return payload, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil { // Failed to read body
+		return payload, err
+	}
+
+	if res.StatusCode >= 200 && res.StatusCode < 300 { // Success!
+		json.Unmarshal(body, &payload)
+		return payload, nil
+	}
+
+	// Handle failure modes
+	var status apiStatus
+	err = json.Unmarshal(body, &status)
+	if err != nil {
+		return payload, err
+	}
+	return payload, fmt.Errorf("Code (%d): %s", status.Code, status.Message)
 }
 
 func getOptionsString(options map[string]string, availableOptions map[string]struct{}) string {


### PR DESCRIPTION
Existing code performed no error checks, so errors other than transport
layer were never reported.  This commit should return all relevant
errors.

Also included in this commit is a rate limiter, however due to the
curious rate limiting implementation on TMDB, this requires forcing
requests to be performed consecutively.

I tried a few strategies for rate limiting, but due to the windowed nature of their rate limiting, and that it's IP-based, I couldn't make any workable with concurrency.  I'm open to ideas if you have any, but this has been quite reliable in my testing.  I haven't managed to run the tests locally either, need to work out what all the yaml vars should be.