### PR TITLE
Adds OriginalTitle to be able to decode Movie results

### DIFF
--- a/search.go
+++ b/search.go
@@ -74,6 +74,7 @@ type MultiSearchResults struct {
 		ID            int
 		OriginalName  string   `json:"original_name"`
 		OriginalTitle string   `json:"original_title"`
+		Overview      string   `json:"overview"`
 		FirstAirDate  string   `json:"first_air_date"`
 		OriginCountry []string `json:"origin_country"`
 		PosterPath    string   `json:"poster_path"`

--- a/search.go
+++ b/search.go
@@ -73,6 +73,7 @@ type MultiSearchResults struct {
 		BackdropPath  string `json:"backdrop_path"`
 		ID            int
 		OriginalName  string   `json:"original_name"`
+		OriginalTitle string   `json:"original_title"`
 		FirstAirDate  string   `json:"first_air_date"`
 		OriginCountry []string `json:"origin_country"`
 		PosterPath    string   `json:"poster_path"`


### PR DESCRIPTION
In MultiSearch, results with `type: 'movie'` have their title in a field called `original_title`.

I'm new to go, so if there's a more elegant way to negotiate which field is unmarshalled, please let me know :)