### PR TITLE
fixed waiting for rateLimitReset wait

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func getTmdb(url string, payload interface{}) (interface{}, error) {
 	now := time.Now()
 	if rateLimitReset.After(now) { // We have a reset time in the future, so we're out of requests
 		// Wait for rate limiter to be reset
-		<-time.After(now.Sub(rateLimitReset))
+		<-time.After(rateLimitReset.Sub(now))
 	}
 
 	res, err := http.Get(url)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func getTmdb(url string, payload interface{}) (interface{}, error) {
 		iReset, err := strconv.ParseInt(reset, 10, 64)
 		if err == nil {
 			// Set the reset time here, the next request will trip it
-			rateLimitReset = time.Unix(iReset, 0)
+			rateLimitReset = time.Unix(iReset+1, 0)
 		}
 	}
 


### PR DESCRIPTION
After receiving rate-limit header, the wait never waited and therefore all requests went through and got an error regarding the rate limit.

I found the hint for this fix in #7 
