### PR TITLE
updating type of the movie video id

### DIFF
--- a/movies.go
+++ b/movies.go
@@ -341,7 +341,7 @@ type MovieTranslations struct {
 type MovieVideos struct {
 	ID      int
 	Results []struct {
-		ID       int
+		ID       string
 		Iso639_1 string `json:"iso_639_1"`
 		Key      string
 		Name     string


### PR DESCRIPTION
When you make a request to the following url, you will quickly notice that the video ids (essentially the first and only element in "results") has a hash string value instead of an integer value.

https://api.themoviedb.org/3/movie/351286/videos?api_key=<your_api_key>

This change fixes that issue. Otherwise, the video id will always be 0.