### PR TITLE
Updates all documentation links to current docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Create a local.yml file in the root directory that mirrors the local.yml.example
 
 ## Available methods
 
-All themoviedb.org API v3 GET methods are included. The POST and DELETE APIs are not included yet. For examples on how to call each function, refer to that function's tests. For documentation of the TheMovieDB's API, see their [documentation](http://docs.themoviedb.apiary.io/).
+All themoviedb.org API v3 GET methods are included. The POST and DELETE APIs are not included yet. For examples on how to call each function, refer to that function's tests. For documentation of the TheMovieDB's API, see their [documentation](https://developers.themoviedb.org/3/).
 
 ## License 
 

--- a/account.go
+++ b/account.go
@@ -15,7 +15,7 @@ type AccountInfo struct {
 }
 
 // GetAccountInfo gets the basic information for an account
-// http://docs.themoviedb.apiary.io/#reference/account/account/get
+// https://developers.themoviedb.org/3/account/get-account-details
 func (tmdb *TMDb) GetAccountInfo(sessionID string) (*AccountInfo, error) {
 	var account AccountInfo
 	uri := fmt.Sprintf("%s/account?api_key=%s&session_id=%s", baseURL, tmdb.apiKey, sessionID)
@@ -24,7 +24,7 @@ func (tmdb *TMDb) GetAccountInfo(sessionID string) (*AccountInfo, error) {
 }
 
 // GetAccountLists gets the lists that you have created and marked as a favorite
-// http://docs.themoviedb.apiary.io/#reference/account/accountidlists/get
+// https://developers.themoviedb.org/3/account/get-created-lists
 func (tmdb *TMDb) GetAccountLists(id int, sessionID string, options map[string]string) (*MovieLists, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -37,7 +37,7 @@ func (tmdb *TMDb) GetAccountLists(id int, sessionID string, options map[string]s
 }
 
 // GetAccountFavoriteMovies gets the list of favorite movies for an account
-// http://docs.themoviedb.apiary.io/#reference/account/accountidfavoritemovies/get
+// https://developers.themoviedb.org/3/account/get-favorite-movies
 func (tmdb *TMDb) GetAccountFavoriteMovies(id int, sessionID string, options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -51,7 +51,7 @@ func (tmdb *TMDb) GetAccountFavoriteMovies(id int, sessionID string, options map
 }
 
 // GetAccountFavoriteTv gets the list of favorite movies for an account
-// http://docs.themoviedb.apiary.io/#reference/account/accountidfavoritetv/get
+// https://developers.themoviedb.org/3/account/get-favorite-tv-shows
 func (tmdb *TMDb) GetAccountFavoriteTv(id int, sessionID string, options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -65,7 +65,7 @@ func (tmdb *TMDb) GetAccountFavoriteTv(id int, sessionID string, options map[str
 }
 
 // GetAccountRatedMovies gets the list of rated movies (and associated rating) for an account
-// http://docs.themoviedb.apiary.io/#reference/account/accountidratedmovies/get
+// https://developers.themoviedb.org/3/account/get-rated-movies
 func (tmdb *TMDb) GetAccountRatedMovies(id int, sessionID string, options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -79,7 +79,7 @@ func (tmdb *TMDb) GetAccountRatedMovies(id int, sessionID string, options map[st
 }
 
 // GetAccountRatedTv gets the list of rated TV shows (and associated rating) for an account
-// http://docs.themoviedb.apiary.io/#reference/account/accountidratedtv/get
+// https://developers.themoviedb.org/3/account/get-rated-tv-shows
 func (tmdb *TMDb) GetAccountRatedTv(id int, sessionID string, options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -93,7 +93,7 @@ func (tmdb *TMDb) GetAccountRatedTv(id int, sessionID string, options map[string
 }
 
 // GetAccountWatchlistMovies gets the list of movies on an accounts watchlist
-// http://docs.themoviedb.apiary.io/#reference/account/accountidwatchlistmovies/get
+// https://developers.themoviedb.org/3/account/get-movie-watchlist
 func (tmdb *TMDb) GetAccountWatchlistMovies(id int, sessionID string, options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -107,7 +107,7 @@ func (tmdb *TMDb) GetAccountWatchlistMovies(id int, sessionID string, options ma
 }
 
 // GetAccountWatchlistTv gets the list of TV series on an accounts watchlist
-// http://docs.themoviedb.apiary.io/#reference/account/accountidwatchlisttv/get
+// https://developers.themoviedb.org/3/account/get-tv-show-watchlist
 func (tmdb *TMDb) GetAccountWatchlistTv(id int, sessionID string, options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},

--- a/authentication.go
+++ b/authentication.go
@@ -25,7 +25,7 @@ type AuthenticationGuestSession struct {
 }
 
 // GetAuthToken generates a valid request token for user based authentication
-// http://docs.themoviedb.apiary.io/#reference/authentication/authenticationtokennew/get
+// https://developers.themoviedb.org/3/authentication/create-request-token
 func (tmdb *TMDb) GetAuthToken() (*AuthenticationToken, error) {
 	var token AuthenticationToken
 	uri := fmt.Sprintf("%s/authentication/token/new?api_key=%s", baseURL, tmdb.apiKey)
@@ -34,7 +34,7 @@ func (tmdb *TMDb) GetAuthToken() (*AuthenticationToken, error) {
 }
 
 // GetAuthValidateToken authenticates a user with a TMDb username and password
-// http://docs.themoviedb.apiary.io/#reference/authentication/authenticationtokenvalidatewithlogin/get
+// https://developers.themoviedb.org/3/authentication/validate-request-token
 func (tmdb *TMDb) GetAuthValidateToken(token, user, password string) (*AuthenticationToken, error) {
 	var validToken AuthenticationToken
 	uri := fmt.Sprintf("%s/authentication/token/validate_with_login?api_key=%s&request_token=%s&username=%s&password=%s", baseURL, tmdb.apiKey, token, user, password)
@@ -43,7 +43,7 @@ func (tmdb *TMDb) GetAuthValidateToken(token, user, password string) (*Authentic
 }
 
 // GetAuthSession generates a session id for user based authentication
-// http://docs.themoviedb.apiary.io/#reference/authentication/authenticationsessionnew/get
+// https://developers.themoviedb.org/3/authentication/create-session
 func (tmdb *TMDb) GetAuthSession(token string) (*AuthenticationSession, error) {
 	var session AuthenticationSession
 	uri := fmt.Sprintf("%s/authentication/session/new?api_key=%s&request_token=%s", baseURL, tmdb.apiKey, token)
@@ -52,7 +52,7 @@ func (tmdb *TMDb) GetAuthSession(token string) (*AuthenticationSession, error) {
 }
 
 // GetAuthGuestSession generates a valid request token for user based authentication
-// http://docs.themoviedb.apiary.io/#reference/authentication/authenticationguestsessionnew/get
+// https://developers.themoviedb.org/3/authentication/create-guest-session
 func (tmdb *TMDb) GetAuthGuestSession() (*AuthenticationGuestSession, error) {
 	var session AuthenticationGuestSession
 	uri := fmt.Sprintf("%s/authentication/guest_session/new?api_key=%s", baseURL, tmdb.apiKey)

--- a/certifications.go
+++ b/certifications.go
@@ -14,7 +14,7 @@ type Certification struct {
 }
 
 // GetCertificationsMovieList for movies
-// http://docs.themoviedb.apiary.io/#reference/certifications/certificationmovielist/get
+// https://developers.themoviedb.org/3/certifications/get-movie-certifications
 func (tmdb *TMDb) GetCertificationsMovieList() (*Certification, error) {
 	var movieCert Certification
 	uri := fmt.Sprintf("%s/certification/movie/list?api_key=%s", baseURL, tmdb.apiKey)
@@ -23,7 +23,7 @@ func (tmdb *TMDb) GetCertificationsMovieList() (*Certification, error) {
 }
 
 // GetCertificationsTvList for tv shows
-// http://docs.themoviedb.apiary.io/#reference/certifications/certificationtvlist/get
+// https://developers.themoviedb.org/3/certifications/get-tv-certifications
 func (tmdb *TMDb) GetCertificationsTvList() (*Certification, error) {
 	var tvCert Certification
 	uri := fmt.Sprintf("%s/certification/tv/list?api_key=%s", baseURL, tmdb.apiKey)

--- a/changes.go
+++ b/changes.go
@@ -18,7 +18,7 @@ var changeOptions = map[string]struct{}{
 	"end_date":   {}}
 
 // GetChangesMovie gets a list of movie ids that have been edited
-// http://docs.themoviedb.apiary.io/#reference/changes/moviechanges/get
+// https://developers.themoviedb.org/3/changes/get-movie-change-list
 func (tmdb *TMDb) GetChangesMovie(options map[string]string) (*Changes, error) {
 	var movieChanges Changes
 	optionsString := getOptionsString(options, changeOptions)
@@ -28,7 +28,7 @@ func (tmdb *TMDb) GetChangesMovie(options map[string]string) (*Changes, error) {
 }
 
 // GetChangesPerson gets a list of people ids that have been edited
-// http://docs.themoviedb.apiary.io/#reference/changes/personchanges/get
+// https://developers.themoviedb.org/3/changes/get-person-change-list
 func (tmdb *TMDb) GetChangesPerson(options map[string]string) (*Changes, error) {
 	var personChanges Changes
 	optionsString := getOptionsString(options, changeOptions)
@@ -38,7 +38,7 @@ func (tmdb *TMDb) GetChangesPerson(options map[string]string) (*Changes, error) 
 }
 
 // GetChangesTv gets a list of tv show ids that have been edited
-// http://docs.themoviedb.apiary.io/#reference/changes/tvchanges/get
+// https://developers.themoviedb.org/3/changes/get-tv-change-list
 func (tmdb *TMDb) GetChangesTv(options map[string]string) (*Changes, error) {
 	var tvChanges Changes
 	optionsString := getOptionsString(options, changeOptions)

--- a/collections.go
+++ b/collections.go
@@ -47,7 +47,7 @@ type CollectionImages struct {
 }
 
 // GetCollectionInfo gets the basic collection information for a specific collection id
-// http://docs.themoviedb.apiary.io/#reference/collections/collectionid/get
+// https://developers.themoviedb.org/3/collections/get-collection-details
 func (tmdb *TMDb) GetCollectionInfo(id int, options map[string]string) (*Collection, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -60,7 +60,7 @@ func (tmdb *TMDb) GetCollectionInfo(id int, options map[string]string) (*Collect
 }
 
 // GetCollectionImages gets a list of people ids that have been edited
-// http://docs.themoviedb.apiary.io/#reference/collections/collectionidimages/get
+// https://developers.themoviedb.org/3/collections/get-collection-images
 func (tmdb *TMDb) GetCollectionImages(id int, options map[string]string) (*CollectionImages, error) {
 	var availableOptions = map[string]struct{}{
 		"language":               {},

--- a/companies.go
+++ b/companies.go
@@ -21,7 +21,7 @@ type Company struct {
 }
 
 // GetCompanyInfo gets all of the basic information about a company
-// http://docs.themoviedb.apiary.io/#reference/companies/companyid/get
+// https://developers.themoviedb.org/3/companies/get-company-details
 func (tmdb *TMDb) GetCompanyInfo(id int, options map[string]string) (*Company, error) {
 	var availableOptions = map[string]struct{}{
 		"append_to_response": {}}
@@ -33,7 +33,7 @@ func (tmdb *TMDb) GetCompanyInfo(id int, options map[string]string) (*Company, e
 }
 
 // GetCompanyMovies gets the list of movies associated with a particular company
-// http://docs.themoviedb.apiary.io/#reference/companies/companyidmovies/get
+// No current documentation exists for this endpoint
 func (tmdb *TMDb) GetCompanyMovies(id int, options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":               {},

--- a/configuration.go
+++ b/configuration.go
@@ -19,7 +19,7 @@ type Configuration struct {
 }
 
 // GetConfiguration gets the system wide configuration information
-// http://docs.themoviedb.apiary.io/#reference/configuration/configuration/get
+// https://developers.themoviedb.org/3/configuration/get-api-configuration
 func (tmdb *TMDb) GetConfiguration() (*Configuration, error) {
 	var config Configuration
 	uri := fmt.Sprintf("%s/configuration?api_key=%s", baseURL, tmdb.apiKey)

--- a/credits.go
+++ b/credits.go
@@ -37,7 +37,7 @@ type Credit struct {
 }
 
 // GetCreditInfo gets the detailed information about a particular credit record
-// http://docs.themoviedb.apiary.io/#reference/credits/creditcreditid/get
+// https://developers.themoviedb.org/3/credits/get-credit-details
 func (tmdb *TMDb) GetCreditInfo(id string, options map[string]string) (*Credit, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}

--- a/discover.go
+++ b/discover.go
@@ -5,7 +5,7 @@ import (
 )
 
 // DiscoverMovie discovers movies by different types of data like average rating, number of votes, genres and certifications
-// http://docs.themoviedb.apiary.io/#reference/discover/discovermovie/get
+// https://developers.themoviedb.org/3/discover/movie-discover
 func (tmdb *TMDb) DiscoverMovie(options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"certification_country":    {},
@@ -40,7 +40,7 @@ func (tmdb *TMDb) DiscoverMovie(options map[string]string) (*MoviePagedResults, 
 }
 
 // DiscoverTV discovers TV shows by different types of data like average rating, number of votes, genres, the network they aired on and air dates
-// http://docs.themoviedb.apiary.io/#reference/discover/discovertv/get
+// https://developers.themoviedb.org/3/discover/tv-discover
 func (tmdb *TMDb) DiscoverTV(options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":                {},

--- a/find.go
+++ b/find.go
@@ -30,7 +30,7 @@ type FindResults struct {
 }
 
 // GetFind makes it easy to search for objects in our database by an external id
-// http://docs.themoviedb.apiary.io/#reference/find/findid/get
+// https://developers.themoviedb.org/3/find/find-by-id
 func (tmdb *TMDb) GetFind(id, source string, options map[string]string) (*FindResults, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}

--- a/genres.go
+++ b/genres.go
@@ -13,7 +13,7 @@ type Genre struct {
 }
 
 // GetMovieGenres gets the list of movie genres
-// http://docs.themoviedb.apiary.io/#reference/genres/genremovielist/get
+// https://developers.themoviedb.org/3/genres/get-movie-list
 func (tmdb *TMDb) GetMovieGenres(options map[string]string) (*Genre, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}
@@ -25,7 +25,7 @@ func (tmdb *TMDb) GetMovieGenres(options map[string]string) (*Genre, error) {
 }
 
 // GetTvGenres gets the list of TV genres
-// http://docs.themoviedb.apiary.io/#reference/genres/genretvlist/get
+// https://developers.themoviedb.org/3/genres/get-tv-list
 func (tmdb *TMDb) GetTvGenres(options map[string]string) (*Genre, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}

--- a/guestsessions.go
+++ b/guestsessions.go
@@ -5,7 +5,7 @@ import (
 )
 
 // GetGuestSessionRatedMovies gets the list of rated movies for a specific guest session id
-// http://docs.themoviedb.apiary.io/#reference/guest-sessions/guestsessionguestsessionidratedmovies/get
+// https://developers.themoviedb.org/3/guest-sessions/get-guest-session-rated-movies
 func (tmdb *TMDb) GetGuestSessionRatedMovies(sessionID string, options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":       {},

--- a/jobs.go
+++ b/jobs.go
@@ -13,7 +13,7 @@ type Job struct {
 }
 
 // GetJobList gets a list of valid jobs
-// http://docs.themoviedb.apiary.io/#reference/jobs/joblist/get
+// https://developers.themoviedb.org/3/configuration/get-jobs
 func (tmdb *TMDb) GetJobList() (*Job, error) {
 	var jobList Job
 	uri := fmt.Sprintf("%s/job/list?api_key=%s", baseURL, tmdb.apiKey)

--- a/keywords.go
+++ b/keywords.go
@@ -11,7 +11,7 @@ type Keyword struct {
 }
 
 // GetKeywordInfo gets the basic information for a specific keyword id
-// http://docs.themoviedb.apiary.io/#reference/keywords/keywordid/get
+// https://developers.themoviedb.org/3/keywords/get-keyword-details
 func (tmdb *TMDb) GetKeywordInfo(id int) (*Keyword, error) {
 	var keywordInfo Keyword
 	uri := fmt.Sprintf("%s/keyword/%v?api_key=%s", baseURL, id, tmdb.apiKey)
@@ -20,7 +20,7 @@ func (tmdb *TMDb) GetKeywordInfo(id int) (*Keyword, error) {
 }
 
 // GetKeywordMovies gets the list of movies for a particular keyword by id
-// http://docs.themoviedb.apiary.io/#reference/keywords/keywordidmovies/get
+// https://developers.themoviedb.org/3/keywords/get-movies-by-keyword
 func (tmdb *TMDb) GetKeywordMovies(id int, options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {},

--- a/lists.go
+++ b/lists.go
@@ -24,7 +24,7 @@ type ListItemStatus struct {
 }
 
 // GetListInfo gets a list by id
-// http://docs.themoviedb.apiary.io/#reference/lists/listid/get
+// https://developers.themoviedb.org/3/lists/get-list-details
 func (tmdb *TMDb) GetListInfo(id string) (*ListInfo, error) {
 	var listInfo ListInfo
 	uri := fmt.Sprintf("%s/list/%v?api_key=%s", baseURL, id, tmdb.apiKey)
@@ -33,13 +33,13 @@ func (tmdb *TMDb) GetListInfo(id string) (*ListInfo, error) {
 }
 
 // DeleteList deletes a list by id
-// http://docs.themoviedb.apiary.io/#reference/lists/listid/delete
+// https://developers.themoviedb.org/3/lists/delete-list
 // func (tmdb *TMDb) DeleteList(id string) {
 // TODO
 // }
 
 // GetListItemStatus checks to see if a movie ID is already added to a list
-// http://docs.themoviedb.apiary.io/#reference/lists/listiditemstatus/get
+// hhttps://developers.themoviedb.org/3/lists/check-item-status
 func (tmdb *TMDb) GetListItemStatus(id string, movieID int) (*ListItemStatus, error) {
 	var itemStatus ListItemStatus
 	uri := fmt.Sprintf("%s/list/%v/item_status?api_key=%s&movie_id=%v", baseURL, id, tmdb.apiKey, movieID)
@@ -48,19 +48,19 @@ func (tmdb *TMDb) GetListItemStatus(id string, movieID int) (*ListItemStatus, er
 }
 
 // PostListAddItem lets users add new movies to a list that they created
-// http://docs.themoviedb.apiary.io/#reference/lists/listidadditem/post
+// https://developers.themoviedb.org/3/lists/add-movie
 // func (tmdb *TMDb) PostListAddItem(id string) {
 // TODO
 // }
 
 // PostListRemoveItem lets users remove movies from a list that they created
-// http://docs.themoviedb.apiary.io/#reference/lists/listidremoveitem/post
+// https://developers.themoviedb.org/3/lists/remove-movie
 // func (tmdb *TMDb) PostListRemoveItem(id string) {
 // TODO
 // }
 
 // PostListClear clears all of the items in a list
-// http://docs.themoviedb.apiary.io/#reference/lists/listidclear/post
+// https://developers.themoviedb.org/3/lists/clear-list
 // func (tmdb *TMDb) PostListRemoveItem(id string) {
 // TODO
 // }

--- a/movies.go
+++ b/movies.go
@@ -403,7 +403,7 @@ type MovieVideos struct {
 }
 
 // GetMovieInfo for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieid/get
+// https://developers.themoviedb.org/3/movies/get-movie-details
 func (tmdb *TMDb) GetMovieInfo(id int, options map[string]string) (*Movie, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -416,7 +416,7 @@ func (tmdb *TMDb) GetMovieInfo(id int, options map[string]string) (*Movie, error
 }
 
 // GetMovieAccountStates gets the status of whether or not the movie has been rated or added to their favourite or movie watch list
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidaccountstates/get
+// https://developers.themoviedb.org/3/movies/get-movie-account-states
 func (tmdb *TMDb) GetMovieAccountStates(id int, sessionID string) (*MovieAccountState, error) {
 	var state MovieAccountState
 	uri := fmt.Sprintf("%s/movie/%v/account_states?api_key=%s&session_id=%s", baseURL, id, tmdb.apiKey, sessionID)
@@ -425,7 +425,7 @@ func (tmdb *TMDb) GetMovieAccountStates(id int, sessionID string) (*MovieAccount
 }
 
 // GetMovieAlternativeTitles for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidalternativetitles/get
+// https://developers.themoviedb.org/3/movies/get-movie-alternative-titles
 func (tmdb *TMDb) GetMovieAlternativeTitles(id int, options map[string]string) (*MovieAlternativeTitles, error) {
 	var availableOptions = map[string]struct{}{
 		"country":            {},
@@ -438,7 +438,7 @@ func (tmdb *TMDb) GetMovieAlternativeTitles(id int, options map[string]string) (
 }
 
 // GetMovieChanges for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidchanges/get
+// https://developers.themoviedb.org/3/movies/get-movie-changes
 func (tmdb *TMDb) GetMovieChanges(id int, options map[string]string) (*MovieChanges, error) {
 	var availableOptions = map[string]struct{}{
 		"start_date": {},
@@ -451,7 +451,7 @@ func (tmdb *TMDb) GetMovieChanges(id int, options map[string]string) (*MovieChan
 }
 
 // GetMovieCredits for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidcredits/get
+// https://developers.themoviedb.org/3/movies/get-movie-credits
 func (tmdb *TMDb) GetMovieCredits(id int, options map[string]string) (*MovieCredits, error) {
 	var availableOptions = map[string]struct{}{
 		"append_to_response": {}}
@@ -463,7 +463,7 @@ func (tmdb *TMDb) GetMovieCredits(id int, options map[string]string) (*MovieCred
 }
 
 // GetMovieImages for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidimages/get
+// https://developers.themoviedb.org/3/movies/get-movie-images
 func (tmdb *TMDb) GetMovieImages(id int, options map[string]string) (*MovieImages, error) {
 	var availableOptions = map[string]struct{}{
 		"language":               {},
@@ -477,7 +477,7 @@ func (tmdb *TMDb) GetMovieImages(id int, options map[string]string) (*MovieImage
 }
 
 // GetMovieKeywords for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidkeywords/get
+// https://developers.themoviedb.org/3/movies/get-movie-keywords
 func (tmdb *TMDb) GetMovieKeywords(id int, options map[string]string) (*MovieKeywords, error) {
 	var availableOptions = map[string]struct{}{
 		"append_to_response": {}}
@@ -489,7 +489,7 @@ func (tmdb *TMDb) GetMovieKeywords(id int, options map[string]string) (*MovieKey
 }
 
 // GetMovieLatest gets the latest movie
-// http://docs.themoviedb.apiary.io/#reference/movies/movielatest/get
+// https://developers.themoviedb.org/3/movies/get-latest-movie
 func (tmdb *TMDb) GetMovieLatest() (*Movie, error) {
 	var movie Movie
 	uri := fmt.Sprintf("%s/movie/latest?api_key=%s", baseURL, tmdb.apiKey)
@@ -498,7 +498,7 @@ func (tmdb *TMDb) GetMovieLatest() (*Movie, error) {
 }
 
 // GetMovieLists that the movie belongs to
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidlists/get
+// https://developers.themoviedb.org/3/movies/get-movie-lists
 func (tmdb *TMDb) GetMovieLists(id int, options map[string]string) (*MovieLists, error) {
 	var availableOptions = map[string]struct{}{
 		"page":               {},
@@ -512,7 +512,7 @@ func (tmdb *TMDb) GetMovieLists(id int, options map[string]string) (*MovieLists,
 }
 
 // GetMovieNowPlaying that have been, or are being released this week
-// http://docs.themoviedb.apiary.io/#reference/movies/movienowplaying/get
+// https://developers.themoviedb.org/3/movies/get-now-playing
 func (tmdb *TMDb) GetMovieNowPlaying(options map[string]string) (*MovieDatedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -525,7 +525,7 @@ func (tmdb *TMDb) GetMovieNowPlaying(options map[string]string) (*MovieDatedResu
 }
 
 // GetMoviePopular gets the list of popular movies on The Movie Database
-// http://docs.themoviedb.apiary.io/#reference/movies/moviepopular/get
+// https://developers.themoviedb.org/3/movies/get-popular-movies
 func (tmdb *TMDb) GetMoviePopular(options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -538,7 +538,7 @@ func (tmdb *TMDb) GetMoviePopular(options map[string]string) (*MoviePagedResults
 }
 
 // GetMovieReleases for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidreleases/get
+// https://developers.themoviedb.org/3/movies/get-movie-release-dates
 func (tmdb *TMDb) GetMovieReleases(id int, options map[string]string) (*MovieReleases, error) {
 	var availableOptions = map[string]struct{}{
 		"append_to_response": {}}
@@ -550,7 +550,7 @@ func (tmdb *TMDb) GetMovieReleases(id int, options map[string]string) (*MovieRel
 }
 
 // GetMovieReviews for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidreviews/get
+// https://developers.themoviedb.org/3/movies/get-movie-reviews
 func (tmdb *TMDb) GetMovieReviews(id int, options map[string]string) (*MovieReviews, error) {
 	var availableOptions = map[string]struct{}{
 		"page":               {},
@@ -564,7 +564,7 @@ func (tmdb *TMDb) GetMovieReviews(id int, options map[string]string) (*MovieRevi
 }
 
 // GetMovieSimilar for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidsimilar/get
+// https://developers.themoviedb.org/3/movies/get-similar-movies
 func (tmdb *TMDb) GetMovieSimilar(id int, options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":               {},
@@ -578,7 +578,7 @@ func (tmdb *TMDb) GetMovieSimilar(id int, options map[string]string) (*MoviePage
 }
 
 // GetMovieTopRated gets the list of top rated movies
-// http://docs.themoviedb.apiary.io/#reference/movies/movietoprated/get
+// https://developers.themoviedb.org/3/movies/get-top-rated-movies
 func (tmdb *TMDb) GetMovieTopRated(options map[string]string) (*MoviePagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -591,7 +591,7 @@ func (tmdb *TMDb) GetMovieTopRated(options map[string]string) (*MoviePagedResult
 }
 
 // GetMovieTranslations for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidtranslations/get
+// https://developers.themoviedb.org/3/movies/get-movie-translations
 func (tmdb *TMDb) GetMovieTranslations(id int, options map[string]string) (*MovieTranslations, error) {
 	var availableOptions = map[string]struct{}{
 		"append_to_response": {}}
@@ -616,7 +616,7 @@ func (tmdb *TMDb) GetMovieRecommendations(id int, options map[string]string) (*M
 }
 
 // GetMovieVideos for a specific movie id
-// http://docs.themoviedb.apiary.io/#reference/movies/movieidvideos/get
+// https://developers.themoviedb.org/3/movies/get-movie-recommendations
 func (tmdb *TMDb) GetMovieVideos(id int, options map[string]string) (*MovieVideos, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -629,7 +629,7 @@ func (tmdb *TMDb) GetMovieVideos(id int, options map[string]string) (*MovieVideo
 }
 
 // GetMovieUpcoming by release date
-// http://docs.themoviedb.apiary.io/#reference/movies/movieupcoming/get
+// https://developers.themoviedb.org/3/movies/get-upcoming
 func (tmdb *TMDb) GetMovieUpcoming(options map[string]string) (*MovieDatedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -642,7 +642,7 @@ func (tmdb *TMDb) GetMovieUpcoming(options map[string]string) (*MovieDatedResult
 }
 
 // GetMovieExternalIds gets the external ids for a movie
-// https://developers.themoviedb.org/3/tv/get-movie-external-ids
+// https://developers.themoviedb.org/3/movies/get-movie-external-ids
 func (tmdb *TMDb) GetMovieExternalIds(movieID int, options map[string]string) (*MovieExternalIds, error) {
 	// currently there are not options, left it so it may be updated in the future without breaking existing code
 	var ids MovieExternalIds
@@ -652,7 +652,7 @@ func (tmdb *TMDb) GetMovieExternalIds(movieID int, options map[string]string) (*
 }
 
 // // SetMovieRating lets users rate a movie
-// // http://docs.themoviedb.apiary.io/#reference/movies/movieidrating/post
+// // https://developers.themoviedb.org/3/movies/rate-movie
 // func (tmdb *TMDb) SetMovieRating(id int) (*MovieRating, error) {
 // 	// TODO
 // 	var rating MovieRating

--- a/networks.go
+++ b/networks.go
@@ -11,7 +11,7 @@ type Network struct {
 }
 
 // GetNetworkInfo gets the basic information about a TV network
-// http://docs.themoviedb.apiary.io/#reference/networks/networkid/get
+// https://developers.themoviedb.org/3/networks/get-network-details
 func (tmdb *TMDb) GetNetworkInfo(id int) (*Network, error) {
 	var networkInfo Network
 	uri := fmt.Sprintf("%s/network/%v?api_key=%s", baseURL, id, tmdb.apiKey)

--- a/people.go
+++ b/people.go
@@ -213,7 +213,7 @@ type PersonTvCredits struct {
 }
 
 // GetPersonInfo gets the general person information for a specific id
-// http://docs.themoviedb.apiary.io/#reference/people/personid/get
+// https://developers.themoviedb.org/3/people/get-person-details
 func (tmdb *TMDb) GetPersonInfo(id int, options map[string]string) (*Person, error) {
 	var availableOptions = map[string]struct{}{
 		"append_to_response": {}}
@@ -225,7 +225,7 @@ func (tmdb *TMDb) GetPersonInfo(id int, options map[string]string) (*Person, err
 }
 
 // GetPersonChanges for a specific person id
-// http://docs.themoviedb.apiary.io/#reference/people/personidchanges/get
+// https://developers.themoviedb.org/3/people/get-person-changes
 func (tmdb *TMDb) GetPersonChanges(id int, options map[string]string) (*PersonChanges, error) {
 	var availableOptions = map[string]struct{}{
 		"start_date": {},
@@ -238,7 +238,7 @@ func (tmdb *TMDb) GetPersonChanges(id int, options map[string]string) (*PersonCh
 }
 
 // GetPersonCombinedCredits gets the combined (movie and TV) credits for a specific person id
-// http://docs.themoviedb.apiary.io/#reference/people/personidcombinedcredits/get
+// https://developers.themoviedb.org/3/people/get-person-combined-credits
 func (tmdb *TMDb) GetPersonCombinedCredits(id int, options map[string]string) (*PersonCombinedCredits, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -251,7 +251,7 @@ func (tmdb *TMDb) GetPersonCombinedCredits(id int, options map[string]string) (*
 }
 
 // GetPersonExternalIds gets the external ids for a specific person id
-// http://docs.themoviedb.apiary.io/#reference/people/personidexternalids/get
+// https://developers.themoviedb.org/3/people/get-person-external-ids
 func (tmdb *TMDb) GetPersonExternalIds(id int) (*TvExternalIds, error) {
 	var ids TvExternalIds
 	uri := fmt.Sprintf("%s/person/%v/external_ids?api_key=%s", baseURL, id, tmdb.apiKey)
@@ -260,7 +260,7 @@ func (tmdb *TMDb) GetPersonExternalIds(id int) (*TvExternalIds, error) {
 }
 
 // GetPersonImages gets the images for a specific person id
-// http://docs.themoviedb.apiary.io/#reference/people/personidimages/get
+// https://developers.themoviedb.org/3/people/get-person-images
 func (tmdb *TMDb) GetPersonImages(id int) (*PersonImages, error) {
 	var images PersonImages
 	uri := fmt.Sprintf("%s/person/%v/images?api_key=%s", baseURL, id, tmdb.apiKey)
@@ -269,7 +269,7 @@ func (tmdb *TMDb) GetPersonImages(id int) (*PersonImages, error) {
 }
 
 // GetPersonLatest gets the latest person id
-// http://docs.themoviedb.apiary.io/#reference/people/personlatest/get
+// https://developers.themoviedb.org/3/people/get-latest-person
 func (tmdb *TMDb) GetPersonLatest() (*PersonLatest, error) {
 	var latest PersonLatest
 	uri := fmt.Sprintf("%s/person/latest?api_key=%s", baseURL, tmdb.apiKey)
@@ -278,7 +278,7 @@ func (tmdb *TMDb) GetPersonLatest() (*PersonLatest, error) {
 }
 
 // GetPersonMovieCredits gets the movie credits for a specific person id
-// http://docs.themoviedb.apiary.io/#reference/people/personidmoviecredits/get
+// https://developers.themoviedb.org/3/people/get-person-movie-credits
 func (tmdb *TMDb) GetPersonMovieCredits(id int, options map[string]string) (*PersonMovieCredits, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -291,7 +291,7 @@ func (tmdb *TMDb) GetPersonMovieCredits(id int, options map[string]string) (*Per
 }
 
 // GetPersonPopular gets the list of popular people on The Movie Database
-// http://docs.themoviedb.apiary.io/#reference/people/personpopular/get
+// https://developers.themoviedb.org/3/people/get-popular-people
 func (tmdb *TMDb) GetPersonPopular(options map[string]string) (*PersonPopular, error) {
 	var availableOptions = map[string]struct{}{
 		"page": {}}
@@ -303,7 +303,7 @@ func (tmdb *TMDb) GetPersonPopular(options map[string]string) (*PersonPopular, e
 }
 
 // GetPersonTaggedImages gets the images that have been tagged with a specific person id
-// http://docs.themoviedb.apiary.io/#reference/people/personidtaggedimages/get
+// https://developers.themoviedb.org/3/people/get-tagged-images
 func (tmdb *TMDb) GetPersonTaggedImages(id int, options map[string]string) (*PersonTaggedImages, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {},
@@ -316,7 +316,7 @@ func (tmdb *TMDb) GetPersonTaggedImages(id int, options map[string]string) (*Per
 }
 
 // GetPersonTvCredits gets the TV credits for a specific person id
-// http://docs.themoviedb.apiary.io/#reference/people/personidtvcredits/get
+// https://developers.themoviedb.org/3/people/get-person-tv-credits
 func (tmdb *TMDb) GetPersonTvCredits(id int, options map[string]string) (*PersonTvCredits, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},

--- a/reviews.go
+++ b/reviews.go
@@ -17,7 +17,7 @@ type Review struct {
 }
 
 // GetReviewInfo gets the full details of a review by ID
-// http://docs.themoviedb.apiary.io/#reference/reviews/reviewid/get
+// https://developers.themoviedb.org/3/reviews/get-review-details
 func (tmdb *TMDb) GetReviewInfo(id string) (*Review, error) {
 	var reviewInfo Review
 	uri := fmt.Sprintf("%s/review/%v?api_key=%s", baseURL, id, tmdb.apiKey)

--- a/search.go
+++ b/search.go
@@ -297,7 +297,7 @@ type TvSearchResults struct {
 }
 
 // SearchCollection searches for collections by name
-// http://docs.themoviedb.apiary.io/#reference/search/searchcollection/get
+// https://developers.themoviedb.org/3/search/search-collections
 func (tmdb *TMDb) SearchCollection(name string, options map[string]string) (*CollectionSearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -311,7 +311,7 @@ func (tmdb *TMDb) SearchCollection(name string, options map[string]string) (*Col
 }
 
 // SearchCompany searches for companies by name
-// http://docs.themoviedb.apiary.io/#reference/search/searchcompany/get
+// https://developers.themoviedb.org/3/search/search-companies
 func (tmdb *TMDb) SearchCompany(name string, options map[string]string) (*CompanySearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page": {}}
@@ -324,7 +324,7 @@ func (tmdb *TMDb) SearchCompany(name string, options map[string]string) (*Compan
 }
 
 // SearchKeyword searches for keywords by name
-// http://docs.themoviedb.apiary.io/#reference/search/searchkeyword/get
+// https://developers.themoviedb.org/3/search/search-keywords
 func (tmdb *TMDb) SearchKeyword(name string, options map[string]string) (*KeywordSearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page": {}}
@@ -337,7 +337,7 @@ func (tmdb *TMDb) SearchKeyword(name string, options map[string]string) (*Keywor
 }
 
 // SearchList searches for lists by name and description
-// http://docs.themoviedb.apiary.io/#reference/search/searchlist/get
+// No current documentation exists for this endpoint
 func (tmdb *TMDb) SearchList(name string, options map[string]string) (*ListSearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":          {},
@@ -351,7 +351,7 @@ func (tmdb *TMDb) SearchList(name string, options map[string]string) (*ListSearc
 }
 
 // SearchMovie searches for movies by title
-// http://docs.themoviedb.apiary.io/#reference/search/searchmovie/get
+// https://developers.themoviedb.org/3/search/search-movies
 func (tmdb *TMDb) SearchMovie(name string, options map[string]string) (*MovieSearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":                 {},
@@ -369,7 +369,7 @@ func (tmdb *TMDb) SearchMovie(name string, options map[string]string) (*MovieSea
 }
 
 // SearchMulti searches the movie, tv show and person collections with a single query
-// http://docs.themoviedb.apiary.io/#reference/search/searchmulti/get
+// https://developers.themoviedb.org/3/search/multi-search
 func (tmdb *TMDb) SearchMulti(name string, options map[string]string) (*MultiSearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":          {},
@@ -384,7 +384,7 @@ func (tmdb *TMDb) SearchMulti(name string, options map[string]string) (*MultiSea
 }
 
 // SearchPerson searches for people by name
-// http://docs.themoviedb.apiary.io/#reference/search/searchperson/get
+// https://developers.themoviedb.org/3/search/search-people
 func (tmdb *TMDb) SearchPerson(name string, options map[string]string) (*PersonSearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":          {},
@@ -399,7 +399,7 @@ func (tmdb *TMDb) SearchPerson(name string, options map[string]string) (*PersonS
 }
 
 // SearchTv searches for TV shows by title
-// http://docs.themoviedb.apiary.io/#reference/search/searchtv/get
+// https://developers.themoviedb.org/3/search/search-tv-shows
 func (tmdb *TMDb) SearchTv(name string, options map[string]string) (*TvSearchResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":                {},

--- a/timezones.go
+++ b/timezones.go
@@ -8,7 +8,7 @@ import (
 type Timezones []map[string][]string
 
 // GetTimezonesList gets the list of supported timezones
-// http://docs.themoviedb.apiary.io/#reference/timezones/timezoneslist/get
+// https://developers.themoviedb.org/3/configuration/get-timezones
 func (tmdb *TMDb) GetTimezonesList() (*Timezones, error) {
 	var timezoneList Timezones
 	uri := fmt.Sprintf("%s/timezones/list?api_key=%s", baseURL, tmdb.apiKey)

--- a/tv.go
+++ b/tv.go
@@ -275,7 +275,7 @@ type TvVideos struct {
 }
 
 // GetTvInfo gets the primary information about a TV series by id
-// http://docs.themoviedb.apiary.io/#reference/tv/tvid/get
+// https://developers.themoviedb.org/3/tv/get-tv-details
 func (tmdb *TMDb) GetTvInfo(id int, options map[string]string) (*TV, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -288,7 +288,7 @@ func (tmdb *TMDb) GetTvInfo(id int, options map[string]string) (*TV, error) {
 }
 
 // GetTvAccountStates gets the status of whether or not the TV show has been rated or added to their favourite or watch lists
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidaccountstates/get
+// https://developers.themoviedb.org/3/tv/get-tv-account-states
 func (tmdb *TMDb) GetTvAccountStates(id int, sessionID string) (*TvAccountState, error) {
 	var state TvAccountState
 	uri := fmt.Sprintf("%s/tv/%v/account_states?api_key=%s&session_id=%s", baseURL, id, tmdb.apiKey, sessionID)
@@ -297,7 +297,7 @@ func (tmdb *TMDb) GetTvAccountStates(id int, sessionID string) (*TvAccountState,
 }
 
 // GetTvAiringToday gets the list of TV shows that air today
-// http://docs.themoviedb.apiary.io/#reference/tv/tvairingtoday/get
+// https://developers.themoviedb.org/3/tv/get-tv-airing-today
 func (tmdb *TMDb) GetTvAiringToday(options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -311,7 +311,7 @@ func (tmdb *TMDb) GetTvAiringToday(options map[string]string) (*TvPagedResults, 
 }
 
 // GetTvAlternativeTitles gets the alternative titles for a specific show id
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidalternativetitles/get
+// https://developers.themoviedb.org/3/tv/get-tv-alternative-titles
 func (tmdb *TMDb) GetTvAlternativeTitles(id int) (*TvAlternativeTitles, error) {
 	var titles TvAlternativeTitles
 	uri := fmt.Sprintf("%s/tv/%v/alternative_titles?api_key=%s", baseURL, id, tmdb.apiKey)
@@ -320,7 +320,7 @@ func (tmdb *TMDb) GetTvAlternativeTitles(id int) (*TvAlternativeTitles, error) {
 }
 
 // GetTvChanges gets the changes for a specific show id
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidchanges/get
+// https://developers.themoviedb.org/3/tv/get-tv-changes
 func (tmdb *TMDb) GetTvChanges(id int, options map[string]string) (*TvChanges, error) {
 	var availableOptions = map[string]struct{}{
 		"start_date": {},
@@ -333,7 +333,7 @@ func (tmdb *TMDb) GetTvChanges(id int, options map[string]string) (*TvChanges, e
 }
 
 // GetTvCredits gets the credits for a specific TV show id
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidcredits/get
+// https://developers.themoviedb.org/3/tv/get-tv-credits
 func (tmdb *TMDb) GetTvCredits(id int, options map[string]string) (*TvCredits, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -358,7 +358,7 @@ func (tmdb *TMDb) GetTvExternalIds(showID int, options map[string]string) (*TvEx
 }
 
 // GetTvImages gets the images for a TV series
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidimages/get
+// https://developers.themoviedb.org/3/tv/get-tv-images
 func (tmdb *TMDb) GetTvImages(id int, options map[string]string) (*TvImages, error) {
 	var availableOptions = map[string]struct{}{
 		"language":               {},
@@ -371,7 +371,7 @@ func (tmdb *TMDb) GetTvImages(id int, options map[string]string) (*TvImages, err
 }
 
 // GetTvKeywords gets the keywords for a specific TV show id
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidkeywords/get
+// https://developers.themoviedb.org/3/tv/get-tv-keywords
 func (tmdb *TMDb) GetTvKeywords(id int, options map[string]string) (*TvKeywords, error) {
 	var availableOptions = map[string]struct{}{
 		"append_to_response": {}}
@@ -396,7 +396,7 @@ func (tmdb *TMDb) GetTvRecommendations(id int, options map[string]string) (*TvRe
 }
 
 // GetTvLatest gets the latest TV show
-// http://docs.themoviedb.apiary.io/#reference/tv/tvlatest/get
+// https://developers.themoviedb.org/3/tv/get-latest-tv
 func (tmdb *TMDb) GetTvLatest() (*TV, error) {
 	var tv TV
 	uri := fmt.Sprintf("%s/tv/latest?api_key=%s", baseURL, tmdb.apiKey)
@@ -405,7 +405,7 @@ func (tmdb *TMDb) GetTvLatest() (*TV, error) {
 }
 
 // GetTvOnTheAir gets the list of TV shows that are currently on the air
-// http://docs.themoviedb.apiary.io/#reference/tv/tvontheair/get
+// https://developers.themoviedb.org/3/tv/get-tv-on-the-air
 func (tmdb *TMDb) GetTvOnTheAir(options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -418,7 +418,7 @@ func (tmdb *TMDb) GetTvOnTheAir(options map[string]string) (*TvPagedResults, err
 }
 
 // GetTvPopular gets the list of popular TV shows
-// http://docs.themoviedb.apiary.io/#reference/tv/tvpopular/get
+// https://developers.themoviedb.org/3/tv/get-popular-tv-shows
 func (tmdb *TMDb) GetTvPopular(options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -431,7 +431,7 @@ func (tmdb *TMDb) GetTvPopular(options map[string]string) (*TvPagedResults, erro
 }
 
 // GetTvSimilar gets the similar TV shows for a specific tv show id
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidsimilar/get
+// https://developers.themoviedb.org/3/tv/get-similar-tv-shows
 func (tmdb *TMDb) GetTvSimilar(id int, options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":               {},
@@ -445,7 +445,7 @@ func (tmdb *TMDb) GetTvSimilar(id int, options map[string]string) (*TvPagedResul
 }
 
 // GetTvTopRated gets the list of top rated TV shows
-// http://docs.themoviedb.apiary.io/#reference/tv/tvtoprated/get
+// https://developers.themoviedb.org/3/tv/get-top-rated-tv
 func (tmdb *TMDb) GetTvTopRated(options map[string]string) (*TvPagedResults, error) {
 	var availableOptions = map[string]struct{}{
 		"page":     {},
@@ -458,7 +458,7 @@ func (tmdb *TMDb) GetTvTopRated(options map[string]string) (*TvPagedResults, err
 }
 
 // GetTvTranslations gets the list of translations that exist for a TV series
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidtranslations/get
+// https://developers.themoviedb.org/3/tv/get-tv-translations
 func (tmdb *TMDb) GetTvTranslations(id int) (*TvTranslations, error) {
 	var translations TvTranslations
 	uri := fmt.Sprintf("%s/tv/%v/translations?api_key=%s", baseURL, id, tmdb.apiKey)
@@ -467,7 +467,7 @@ func (tmdb *TMDb) GetTvTranslations(id int) (*TvTranslations, error) {
 }
 
 // GetTvVideos gets the videos that have been added to a TV series
-// http://docs.themoviedb.apiary.io/#reference/tv/tvidvideos/get
+// https://developers.themoviedb.org/3/tv/get-tv-videos
 func (tmdb *TMDb) GetTvVideos(id int, options map[string]string) (*TvVideos, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}

--- a/tvepisodes.go
+++ b/tvepisodes.go
@@ -41,7 +41,7 @@ type TvEpisodeImages struct {
 }
 
 // GetTvEpisodeInfo gets the primary information about a TV episode by combination of a season and episode number
-// http://docs.themoviedb.apiary.io/#reference/tv-episodes/tvidseasonseasonnumberepisodeepisodenumber/get
+// https://developers.themoviedb.org/3/tv-episodes/get-tv-episode-details
 func (tmdb *TMDb) GetTvEpisodeInfo(showID, seasonNum, episodeNum int, options map[string]string) (*TvEpisode, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -54,7 +54,7 @@ func (tmdb *TMDb) GetTvEpisodeInfo(showID, seasonNum, episodeNum int, options ma
 }
 
 // GetTvEpisodeChanges gets a TV episode's changes by episode ID
-// http://docs.themoviedb.apiary.io/#reference/tv-episodes/tvepisodeidchanges/get
+// https://developers.themoviedb.org/3/tv-episodes/get-tv-episode-changes
 func (tmdb *TMDb) GetTvEpisodeChanges(id int, options map[string]string) (*TvChanges, error) {
 	var availableOptions = map[string]struct{}{
 		"start_date": {},
@@ -67,7 +67,7 @@ func (tmdb *TMDb) GetTvEpisodeChanges(id int, options map[string]string) (*TvCha
 }
 
 // GetTvEpisodeCredits gets the TV episode credits by combination of season and episode number
-// http://docs.themoviedb.apiary.io/#reference/tv-episodes/tvidseasonseasonnumberepisodeepisodenumbercredits/get
+// https://developers.themoviedb.org/3/tv-episodes/get-tv-episode-credits
 func (tmdb *TMDb) GetTvEpisodeCredits(showID, seasonNum, episodeNum int) (*TvCredits, error) {
 	var credits TvCredits
 	uri := fmt.Sprintf("%s/tv/%v/season/%v/episode/%v/credits?api_key=%s", baseURL, showID, seasonNum, episodeNum, tmdb.apiKey)
@@ -76,7 +76,7 @@ func (tmdb *TMDb) GetTvEpisodeCredits(showID, seasonNum, episodeNum int) (*TvCre
 }
 
 // GetTvEpisodeExternalIds gets the external ids for a TV episode by comabination of a season and episode number
-// http://docs.themoviedb.apiary.io/#reference/tv-episodes/tvidseasonseasonnumberepisodeepisodenumberexternalids/get
+// https://developers.themoviedb.org/3/tv-episodes/get-tv-episode-external-ids
 func (tmdb *TMDb) GetTvEpisodeExternalIds(showID, seasonNum, episodeNum int, options map[string]string) (*TvExternalIds, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}
@@ -88,7 +88,7 @@ func (tmdb *TMDb) GetTvEpisodeExternalIds(showID, seasonNum, episodeNum int, opt
 }
 
 // GetTvEpisodeImages gets the images (episode stills) for a TV episode by combination of a season and episode number
-// http://docs.themoviedb.apiary.io/#reference/tv-episodes/tvidseasonseasonnumberepisodeepisodenumberimages/get
+// https://developers.themoviedb.org/3/tv-episodes/get-tv-episode-images
 func (tmdb *TMDb) GetTvEpisodeImages(showID, seasonNum, episodeNum int) (*TvEpisodeImages, error) {
 	var images TvEpisodeImages
 	uri := fmt.Sprintf("%s/tv/%v/season/%v/episode/%v/images?api_key=%s", baseURL, showID, seasonNum, episodeNum, tmdb.apiKey)
@@ -97,7 +97,7 @@ func (tmdb *TMDb) GetTvEpisodeImages(showID, seasonNum, episodeNum int) (*TvEpis
 }
 
 // GetTvEpisodeVideos gets the videos that have been added to a TV episode
-// http://docs.themoviedb.apiary.io/#reference/tv-episodes/tvidseasonseasonnumberepisodeepisodenumbervideos/get
+// https://developers.themoviedb.org/3/tv-episodes/get-tv-episode-videos
 func (tmdb *TMDb) GetTvEpisodeVideos(showID, seasonNum, episodeNum int, options map[string]string) (*TvVideos, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}

--- a/tvseasons.go
+++ b/tvseasons.go
@@ -33,7 +33,7 @@ type TvSeasonImages struct {
 }
 
 // GetTvSeasonInfo the primary information about a TV season by its season number
-// http://docs.themoviedb.apiary.io/#reference/tv-seasons/tvidseasonseasonnumber/get
+// https://developers.themoviedb.org/3/tv-seasons/get-tv-season-details
 func (tmdb *TMDb) GetTvSeasonInfo(showID, seasonID int, options map[string]string) (*TvSeason, error) {
 	var availableOptions = map[string]struct{}{
 		"language":           {},
@@ -46,7 +46,7 @@ func (tmdb *TMDb) GetTvSeasonInfo(showID, seasonID int, options map[string]strin
 }
 
 // GetTvSeasonChanges gets a TV season's changes by season ID
-// http://docs.themoviedb.apiary.io/#reference/tv-seasons/tvseasonidchanges/get
+// https://developers.themoviedb.org/3/tv-seasons/get-tv-season-changes
 func (tmdb *TMDb) GetTvSeasonChanges(id int, options map[string]string) (*TvChanges, error) {
 	var availableOptions = map[string]struct{}{
 		"start_date": {},
@@ -59,7 +59,7 @@ func (tmdb *TMDb) GetTvSeasonChanges(id int, options map[string]string) (*TvChan
 }
 
 // GetTvSeasonCredits gets the cast & crew credits for a TV season by season number
-// http://docs.themoviedb.apiary.io/#reference/tv-seasons/tvidseasonseasonnumbercredits/get
+// https://developers.themoviedb.org/3/tv-seasons/get-tv-season-credits
 func (tmdb *TMDb) GetTvSeasonCredits(showID, seasonNum int) (*TvCredits, error) {
 	var credits TvCredits
 	uri := fmt.Sprintf("%s/tv/%v/season/%v/credits?api_key=%s", baseURL, showID, seasonNum, tmdb.apiKey)
@@ -68,7 +68,7 @@ func (tmdb *TMDb) GetTvSeasonCredits(showID, seasonNum int) (*TvCredits, error) 
 }
 
 // GetTvSeasonExternalIds gets the external ids for a TV season by season number
-// http://docs.themoviedb.apiary.io/#reference/tv-seasons/tvidseasonseasonnumberexternalids/get
+// https://developers.themoviedb.org/3/tv-seasons/get-tv-season-external-ids
 func (tmdb *TMDb) GetTvSeasonExternalIds(showID, seasonNum int, options map[string]string) (*TvExternalIds, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}
@@ -80,7 +80,7 @@ func (tmdb *TMDb) GetTvSeasonExternalIds(showID, seasonNum int, options map[stri
 }
 
 // GetTvSeasonImages gets the images (posters) that we have stored for a TV season by season number
-// http://docs.themoviedb.apiary.io/#reference/tv-seasons/tvidseasonseasonnumberimages/get
+// https://developers.themoviedb.org/3/tv-seasons/get-tv-season-images
 func (tmdb *TMDb) GetTvSeasonImages(showID, seasonNum int, options map[string]string) (*TvSeasonImages, error) {
 	var availableOptions = map[string]struct{}{
 		"language":               {},
@@ -93,7 +93,7 @@ func (tmdb *TMDb) GetTvSeasonImages(showID, seasonNum int, options map[string]st
 }
 
 // GetTvSeasonVideos gets the videos that have been added to a TV season
-// http://docs.themoviedb.apiary.io/#reference/tv-seasons/tvidseasonseasonnumbervideos/get
+// https://developers.themoviedb.org/3/tv-seasons/get-tv-season-videos
 func (tmdb *TMDb) GetTvSeasonVideos(showID, seasonNum int, options map[string]string) (*TvVideos, error) {
 	var availableOptions = map[string]struct{}{
 		"language": {}}


### PR DESCRIPTION
Most of the documentation URLs were pointing at the deprecated docs. I've updated them to the version that is being used.

There are 2 exceptions, where no current documentation exists for the endpoint:
 - SearchList
 - GetCompanyMovies

In those cases, I've just left a comment stating no documentation can be found.

Fixes #35 