### PR TITLE
Add Trending API

### DIFF
--- a/trending.go
+++ b/trending.go
@@ -1,0 +1,15 @@
+package tmdb
+
+import (
+	"fmt"
+)
+
+
+// GetTrending get the daily or weekly trending items.
+// https://developers.themoviedb.org/3/trending/get-trending
+func (tmdb *TMDb) GetTrending(media_type,time_window string) (*MoviePagedResults, error) {
+	var nowPlaying MoviePagedResults
+	uri := fmt.Sprintf("%s/trending/%v/%v?api_key=%s", baseURL, media_type, time_window, tmdb.apiKey)
+	result, err := getTmdb(uri, &nowPlaying)
+	return result.(*MoviePagedResults), err
+}

--- a/trending_test.go
+++ b/trending_test.go
@@ -1,0 +1,1 @@
+package tmdb


### PR DESCRIPTION
Adds trending API as implemented in this PR, but without the README changes: https://github.com/ryanbradynd05/go-tmdb/pull/36

Original PR Description:

Trending API is added, it was not included in the library

https://developers.themoviedb.org/3/trending/get-trending