### PR TITLE
Fix person profile picture typo

### DIFF
--- a/search.go
+++ b/search.go
@@ -254,12 +254,12 @@ func (res MultiSearchResults) GetPersonResults() (personResults []MultiSearchPer
 type PersonSearchResults struct {
 	Page    int
 	Results []struct {
-		Adult      bool
-		ID         int
-		Name       string
-		Popularity float32
-		PosterPath string `json:"poster_path"`
-		KnownFor   []struct {
+		Adult       bool
+		ID          int
+		Name        string
+		Popularity  float32
+		ProfilePath string `json:"profile_path"`
+		KnownFor    []struct {
 			Adult         bool
 			BackdropPath  string `json:"backdrop_path"`
 			ID            int


### PR DESCRIPTION
When calling the API, the "poster_path" would always be empty. This is because the API returns a "profile_path" property, and not "poster_path" for Person. Changing the field name in the struct fixes the issue.

---
Before the change
|json|app|
|----|----|
![imagen](https://user-images.githubusercontent.com/10835388/211221935-97cb7c01-f55e-4b66-b546-a102fc1b84d3.png) | ![imagen](https://user-images.githubusercontent.com/10835388/211221945-334988e4-ecb3-40af-8e45-7aa92f2a038b.png)
---
After the change
|json|app|
|----|----|
![imagen](https://user-images.githubusercontent.com/10835388/211222049-4f78d23d-55c0-409d-b245-0e567d20c842.png) | ![imagen](https://user-images.githubusercontent.com/10835388/211222061-2e269fd6-c585-4066-8b30-d54889891a3c.png)

